### PR TITLE
removed copy constructor

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -13,9 +13,6 @@ public:
 	// Creates an empty queue
 	Queue();
 
-	// Creates a queue by performing a shallow copy of q's elements.
-	Queue(Queue* q);
-
 	// Queue destructor
 	virtual ~Queue() {}
 


### PR DESCRIPTION
There is no reason to make a copy of a Queue at this point because they only hold Objects which have no fields to copy